### PR TITLE
New parameter type `asset`

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -70,6 +70,7 @@ tool specification are already covered:
 | file - `.csv`      | :heavy_check_mark:       | :heavy_check_mark: | :heavy_check_mark:                  | :heavy_check_mark:  |
 | file - `.nc`       | :x:                      | :x:                | :x:                                 | :x:                 |
 | file - `.sqlite`   | :x:                      | :x:                | :x:                                 | :x:                 |
+| asset              | :x:                      | :x:                | :x:                                 | :x:                 |
 |    **Parameter fields**                                                                                                       ||
 | array              | :heavy_check_mark:       | :grey_question:    | :grey_question:                     | :grey_question:     |
 | default            | :x:                      | :x:                | :x:                                 | :x:                 |

--- a/docs/parameter.md
+++ b/docs/parameter.md
@@ -74,6 +74,7 @@ Allowed data-types include:
 * boolean
 * enum
 * file
+* asset
 
 #### enum
 
@@ -107,7 +108,12 @@ There are a number of file types, which are loaded by default:
 | file extension | Python |  R  |  Matlab |  NodeJS  |
 | ---------------|--------|-----|---------|----------| 
 | .dat  |  `numpy.array` | `vector` | `matrix`  | `number[][]` | 
-|  .csv |  `pandas.DataFrame` | `data.frame` |  `matrix` |  `number[][]` |
+| .csv  |  `pandas.DataFrame` | `data.frame` |  `matrix` |  `number[][]` |
+
+#### asset
+
+The `type=asset` can be used to specify paths to files or entire folders that are copied unchanged to the `/in/` path of the tool container and thus made available to the tool for further processing. The parsing library never attempts to load and process these files, therefore the files are available in the tool exactly as they are.  
+Assets can be tool configurations, folders containing data, geometry files or all kinds of other files.
 
 ### `description`
 


### PR DESCRIPTION
This Pull Request introduces the new parameter type `asset` to the tool specification.

Assets can be files or folders, that are just copied into the tool container.  
In contrast to the type `file`, assets are never converted into a programming language-specific representation (e.g. csv files as pandas dataframes).