### PR TITLE
Default parameter parsing

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -73,7 +73,7 @@ tool specification are already covered:
 | asset              | :x:                      | :x:                | :x:                                 | :x:                 |
 |    **Parameter fields**                                                                                                       ||
 | array              | :heavy_check_mark:       | :grey_question:    | :grey_question:                     | :grey_question:     |
-| default            | :x:                      | :x:                | :x:                                 | :x:                 |
+| default            | :heavy_check_mark:       | :heavy_check_mark: | :x:                                 | :x:                 |
 | empty parameters*  | :x:                      | :x:                | :x:                                 | :x:                 |
 
 

--- a/docs/parameter.md
+++ b/docs/parameter.md
@@ -144,11 +144,12 @@ Maximum value for constraining the value range. The `max` field is only valid fo
 
 ### `optional`
 
-Boolean field which defaults to `false`. If set to `optional=true`, the parameter is not required by the tool. This implies, that the tool implementation can handle a `parameter.json` in which the `Parameter` is entirely missing.
+Boolean field which defaults to `false`. If set to `optional=true`, the parameter is not required by the tool. This implies, that the tool implementation can handle a `parameters.json` in which the `Parameter` is entirely missing.
 
 ### `default`
 
-The `default` field is of same data type as the `Parameter` itself. If a default value is set, the tool-framework is required to inject this parameter into the `parameters.json`, as the tool will treat the default like any other non-optional parameter. 
+The `default` field is of same data type as the `Parameter` itself. If a default value is set, the tool-framework is required to inject this parameter into the `parameters.json`, as the tool will treat the default like any other non-optional parameter.  
+Note, that default parameters are only parsed if they are not set as `optional=true`.
 
 ## Example
 


### PR DESCRIPTION
The packages json2args (Python) and json2aRgs (R) now support parsing default parameters. Default parameters are only parsed when they are not optional (which is up to discussion).