### PR TITLE
json2args Python and R parse min and max fields

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -74,6 +74,7 @@ tool specification are already covered:
 |    **Parameter fields**                                                                                                       ||
 | array              | :heavy_check_mark:       | :grey_question:    | :grey_question:                     | :grey_question:     |
 | default            | :x:                      | :x:                | :x:                                 | :x:                 |
+| min & max          | :heavy_check_mark:       | :heavy_check_mark: | :x:                                 | :x:                 |
 | empty parameters*  | :x:                      | :x:                | :x:                                 | :x:                 |
 
 

--- a/docs/parameter.md
+++ b/docs/parameter.md
@@ -135,12 +135,13 @@ The `array` field takes a single boolean value and defaults to `array=false`. If
 
 ### `min`
 
-Minimum value for constraining the value range. The `min` field is only valid for `type=integer` and `type=float`. Setting a minimum value is optional and can be omitted.
+Minimum value for constraining the value range. The `min` field is only valid for `type=integer` and `type=float`. Setting a minimum value is optional and can be omitted.  
+Note that if a `max` value is additionally specified for the parameter, `min` must be lower than `max`.
 
 ### `max`
 
-Maximum value for constraining the value range. The `max` field is only valid for `type=integer` and `type=float`. Setting a maximum value is optional and can be omitted.
-
+Maximum value for constraining the value range. The `max` field is only valid for `type=integer` and `type=float`. Setting a maximum value is optional and can be omitted.  
+Note that if a `min` value is additionally specified for the parameter, `max` must be higher than `min`.
 
 ### `optional`
 


### PR DESCRIPTION
The packages json2args (Python) and json2aRgs (R) now support parsing parameters with `min` and `max` fields.

Before merging this PR, the following json2args PRs must be merged:
- [x] https://github.com/hydrocode-de/json2args/pull/4
- [x] https://github.com/VForWaTer/json2aRgs/pull/2