### PR TITLE
Add gotap, update spec and template links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # tool-specs
-This repository includes .yml tool specificiation files for tools implemented in [toolbox-runner](https://github.com/hydrocode-de/tool-runner).
+This repository includes .yml tool specificiation files for tools implemented in [toolbox-runner](https://github.com/tool-spec/tool-runner).
 
-The repository is also used to manage issues and discussions that affect the entire [toolbox-runner](https://github.com/hydrocode-de/tool-runner) stack.
+The repository is also used to manage issues and discussions that affect the entire [toolbox-runner](https://github.com/tool-spec/tool-runner) stack.

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,8 +27,8 @@ extended by any metadata schema.
 
 ## Contributing
 
-To contribute to this specification, you can create a [Fork](https://github.com/VForWaTer/tool-specs/fork) 
-of the repository and adapt as you suggest. Then open a [Pull Request](https://github.com/VForWaTer/tool-specs/comparehttps://github.com/VForWaTer/tool-specs/compare) and your changes will be reviewed.
+To contribute to this specification, you can create a [Fork](https://github.com/tool-spec/tool-specs/fork) 
+of the repository and adapt as you suggest. Then open a [Pull Request](https://github.com/tool-spec/tool-specs/compare) and your changes will be reviewed.
 
 If you like to review upcoming changes, you can mail [@mmaelicke](https://github.com/mmaelicke)
 or [@AlexDo1](https://github.com/AlexDo1) to make you an outside collaborator 
@@ -41,43 +41,42 @@ we are referring to software packages for different programming languages used
 in either of the tools, that help to parse the *parametrization* and the *input data* of a tool into
 a language specific data structure. Here, you can read more about [parameter and data input](./input.md).
 
-The available implementations as of now are:
-  
+The recommended approach is **[gotap](https://github.com/tool-spec/gotap)**. It generates language-specific parameter bindings from `tool.yml` at container build time and is used by all templates. For legacy support, language-specific libraries are also available.
+
 |  library          | Language          |  source repository                          | install                       |  template repo                                    |
 |:------------------|:-----------------:|:-------------------------------------------:|:-----------------------------:|:-------------------------------------------------:|
-| `json2args`       | Python 3.X        | https://github.com/hydrocode-de/json2args | `pip install json2args`         | https://github.com/VForWaTer/tool_template_python | 
-| `json2aRgs`       | R > 3.4           | https://github.com/VForWaTer/json2aRgs    | `install.packages("json2aRgs")` | https://github.com/VForWaTer/tool_template_r      | 
-| `js2args`         | NodeJS > 14       | https://github.com/VForWaTer/js2args      | `npm install js2args`           | https://github.com/vforwater/tool_template_node   | 
-| `getParameters.m` | Octave / MATLAB   | https://github.com/VForWaTer/tool_template_octave | :x:                     | https://github.com/VForWaTer/tool_template_octave | 
+| **gotap**         | All (via generate) | https://github.com/tool-spec/gotap          | built into container          | all templates below                               |
+| `json2args`       | Python 3.X        | https://github.com/tool-spec/json2args | `pip install json2args`         | https://github.com/tool-spec/tool_template_python | 
+| `json2aRgs`       | R > 3.4           | https://github.com/tool-spec/r-json2aRgs | `install.packages("json2aRgs")` | https://github.com/tool-spec/tool_template_r      | 
+| `js2args`         | NodeJS > 14       | https://github.com/tool-spec/js2args      | `npm install js2args`           | https://github.com/tool-spec/tool_template_node   | 
+| `getParameters.m` | Octave / MATLAB   | https://github.com/tool-spec/tool_template_octave | :x:                     | https://github.com/tool-spec/tool_template_octave | 
 
 
 The table below lists which implementation exists and what parts of the
 tool specification are already covered:
 
-
-|  specification        |  json2args (Python 3.X)  | json2aRgs (R)      |  getParameters.m (Octave / MATLAB)  |  js2args (Node.js). |
-|:----------------------|:------------------------:|:------------------:|:-----------------------------------:|:-------------------:|
-|    **Parameter Types**                                                                                                        ||
-| string                | :heavy_check_mark:       | :heavy_check_mark: | :heavy_check_mark:                  | :heavy_check_mark:  |
-| integer               | :heavy_check_mark:       | :heavy_check_mark: | :heavy_check_mark:                  | :heavy_check_mark:  |
-| float                 | :heavy_check_mark:       | :heavy_check_mark: | :heavy_check_mark:                  | :heavy_check_mark:  |
-| enum                  | :heavy_check_mark:       | :heavy_check_mark: | :heavy_check_mark:                  | :heavy_check_mark:  |
-| enum -check values    | :heavy_check_mark:       | :heavy_check_mark: | :x:                                 | :x:                 |
-| boolean               | :heavy_check_mark:       | :heavy_check_mark: | :grey_question:                     | :grey_question:     |
-| datetime              | :heavy_check_mark:       | :heavy_check_mark: | :x:                                 | :heavy_check_mark:  |
-| asset                 | :x:                      | :x:                | :x:                                 | :x:                 |
-|    **Parameter fields**                                                                                                       ||
-| array                 | :heavy_check_mark:       | :heavy_check_mark: | :grey_question:                     | :grey_question:     |
-| default               | :heavy_check_mark:       | :heavy_check_mark: | :x:                                 | :x:                 |
-| min & max             | :heavy_check_mark:       | :heavy_check_mark: | :x:                                 | :x:                 |
-|    **Data fields**                                                                                                            ||
-| extension - `.dat`    | :heavy_check_mark:       | :heavy_check_mark: | :x:                                 | :x:                 |
-| extension - `.csv`    | :heavy_check_mark:       | :heavy_check_mark: | :x:                                 | :x:                 |
-| extension - `.nc`     | :heavy_check_mark:       | :x:                | :x:                                 | :x:                 |
-| extension - `.json`   | :heavy_check_mark:       | :x:                | :x:                                 | :x:                 |
-=======
-| empty input     *     | :x:                      | :x:                | :x:                                 | :x:                 |
-| wildcards             | :heavy_check_mark:       | :x:                | :x:                                 | :x:                 |
+|  specification        |  gotap (all)             | json2args (Python 3.X)  | json2aRgs (R)      |  getParameters.m (Octave / MATLAB)  |  js2args (Node.js). |
+|:----------------------|:------------------------:|:------------------------:|:------------------:|:-----------------------------------:|:-------------------:|
+|    **Parameter Types**                                                                                                        |||
+| string                | :heavy_check_mark:       | :heavy_check_mark:       | :heavy_check_mark: | :heavy_check_mark:                  | :heavy_check_mark:  |
+| integer               | :heavy_check_mark:       | :heavy_check_mark:       | :heavy_check_mark: | :heavy_check_mark:                  | :heavy_check_mark:  |
+| float                 | :heavy_check_mark:       | :heavy_check_mark:       | :heavy_check_mark: | :heavy_check_mark:                  | :heavy_check_mark:  |
+| enum                  | :heavy_check_mark:       | :heavy_check_mark:       | :heavy_check_mark: | :heavy_check_mark:                  | :heavy_check_mark:  |
+| enum -check values    | :heavy_check_mark:       | :heavy_check_mark:       | :x:                | :x:                                 | :x:                 |
+| boolean               | :heavy_check_mark:       | :heavy_check_mark:       | :heavy_check_mark: | :grey_question:                     | :grey_question:     |
+| datetime              | :heavy_check_mark:       | :heavy_check_mark:       | :heavy_check_mark: | :x:                                 | :heavy_check_mark:  |
+| asset                 | :heavy_check_mark:       | :x:                      | :x:                | :x:                                 | :x:                 |
+|    **Parameter fields**                                                                                                       |||
+| array                 | :heavy_check_mark:       | :heavy_check_mark:       | :heavy_check_mark: | :grey_question:                     | :grey_question:     |
+| default               | :heavy_check_mark:       | :heavy_check_mark:       | :heavy_check_mark: | :x:                                 | :x:                 |
+| min & max             | :heavy_check_mark:       | :heavy_check_mark:       | :heavy_check_mark: | :x:                                 | :x:                 |
+|    **Data fields**                                                                                                            |||
+| extension - `.dat`    | :heavy_check_mark:       | :heavy_check_mark:       | :heavy_check_mark: | :x:                                 | :x:                 |
+| extension - `.csv`    | :heavy_check_mark:       | :heavy_check_mark:       | :heavy_check_mark: | :x:                                 | :x:                 |
+| extension - `.nc`     | :heavy_check_mark:       | :heavy_check_mark:       | :x:                | :x:                                 | :x:                 |
+| extension - `.json`   | :heavy_check_mark:       | :heavy_check_mark:       | :x:                | :x:                                 | :x:                 |
+| empty input     *     | :heavy_check_mark:       | :x:                      | :x:                | :x:                                 | :x:                 |
+| wildcards             | :heavy_check_mark:       | :heavy_check_mark:       | :x:                | :x:                                 | :x:                 |
 
 \* `empty input` refers to the input specification requiring implementations to be able to handle empty or missing `/in/input.json` by returing an appropriate empty data structure
 
@@ -88,8 +87,9 @@ directly by operating the docker/podman CLI is the most low-level option and alw
 The listed solutions will take some of the management boilerplate from you and
 might turn out useful.
 
-* [`toolbox-runner`](https://github.com/hydrocode-de/tool-runner) (Python)
-* [`tool-runner-js`](https://github.com/hydrocode-de/tool-runner-js) (NodeJS)
+* [gorun](https://github.com/tool-spec/gorun) (Go)
+* [`toolbox-runner`](https://github.com/tool-spec/tool-runner) (Python)
+* [`tool-runner-js`](https://github.com/tool-spec/tool-runner-js) (NodeJS)
 
 
 ## Contents

--- a/docs/container.md
+++ b/docs/container.md
@@ -14,11 +14,13 @@ In order to work properly, there is a minimum required structure, that the
 container has to follow. In  order to build a container image accordingly,
 there are a number of template repositories on Github:
 
-* [Python template](https://github.com/VForWaTer/tool_template_python)
-* [R template](https://github.com/VForWaTer/tool_template_r)
-* [Node.js template](https://github.com/VForWaTer/tool_template_node)
-* [Octave template](https://github.com/VForWaTer/tool_template_octave)
-* [MATLAB template](https://github.com/VForWaTer/tool_template_matlab)
+* [Python template](https://github.com/tool-spec/tool_template_python)
+* [R template](https://github.com/tool-spec/tool_template_r)
+* [Node.js template](https://github.com/tool-spec/tool_template_node)
+* [Octave template](https://github.com/tool-spec/tool_template_octave)
+* [MATLAB template](https://github.com/tool-spec/tool_template_matlab)
+* [Jupyter template](https://github.com/tool-spec/tool_template_jupyter)
+* [TypeScript template](https://github.com/tool-spec/tool_template_typescript)
 
 The core idea is to enforce a specific structure in the container, so that 
 others know where to find things:
@@ -55,9 +57,13 @@ information about the tool.
 Any executable file is supported. Please note that the tool-specs support only transformation-like tools that terminate *end* upon completion; 
 service tools are not supported.
 
-Please note: In order to work properly with external tools, you implement the 
-execution of the script, as shown in the sample repositories, as the default
-Docker command, **not** entrypoint:
+Templates use [gotap](https://github.com/tool-spec/gotap) as the default Docker command. gotap validates the input and executes the tool:
+
+```Dockerfile
+CMD ["gotap", "run", "<toolname>", "--input-file", "/in/input.json"]
+```
+
+You can also run the script directly (use the Docker command, **not** entrypoint):
 
 ```Dockerfile
 CMD ["python", "run.py"]


### PR DESCRIPTION
## Changes
- Add **gotap** as the recommended implementation (generates bindings from tool.yml at build time)
- Add gotap to the specification coverage table
- Document gotap entrypoint pattern in container.md: `CMD ["gotap", "run", "<toolname>", "--input-file", "/in/input.json"]`
- Update template and framework links (VForWaTer/hydrocode-de -> tool-spec)
- Add TypeScript template to container template list
- Add gorun to Frameworks section
- Fix Contributing fork/PR links

Made with [Cursor](https://cursor.com)